### PR TITLE
Fetch events registered by authenticated user

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,11 +4,14 @@ require('dotenv').config()
 
 const authRoutes = require('./routes/auth.routes')
 const eventRoutes = require('./routes/event.routes')
+const userRoutes = require('./routes/user.routes')
 
 app.use(express.json());
 
 app.use('/auth', authRoutes)
 
 app.use('/events', eventRoutes)
+
+app.use('/users', userRoutes)
 
 module.exports = app

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -1,0 +1,26 @@
+const { success } = require('zod')
+const userService = require('../services/userEvent.service')
+
+async function getMyRegisteredEvents(req, res) {
+    const { userId } = req.user
+
+    try {
+        const events = await userService.getMyRegisteredEvents(userId)
+
+        return res.status(200).json(
+            events
+        )
+
+    } catch (err) {
+        return res.status(500).json({
+            success: false,
+            message: 'Internal server error'
+        })
+    }
+
+}
+
+
+module.exports = {
+    getMyRegisteredEvents
+}

--- a/src/repositories/userEvent.repo.js
+++ b/src/repositories/userEvent.repo.js
@@ -20,7 +20,32 @@ async function createRegistration(userId, eventId) {
 
 }
 
+async function findUserEventsByUserId(userId) {
+    return prisma.userEvent.findMany({
+        where: {
+            userId
+        },
+        select: {
+            event: {
+                select: {
+                    publicId: true,
+                    title: true,
+                    venue: true,
+                    startsAt: true,
+                    creator: {
+                        select: {
+                            firstName: true
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+}
+
 module.exports = {
     exists,
-    createRegistration
+    createRegistration,
+    findUserEventsByUserId
 }

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { getMyRegisteredEvents } = require('../controllers/user.controller')
+const { authMiddleware } = require('../middlewares/auth.middleware')
+
+router.get('/me/events', authMiddleware, getMyRegisteredEvents)
+
+
+module.exports = router

--- a/src/services/userEvent.service.js
+++ b/src/services/userEvent.service.js
@@ -1,0 +1,12 @@
+const { event } = require('../prisma/client')
+const userEventRepo = require('../repositories/userEvent.repo')
+
+async function getMyRegisteredEvents(userId) {
+    const rows = await userEventRepo.findUserEventsByUserId(userId)
+    return rows.map(r => r.event)
+}
+
+
+module.exports = {
+    getMyRegisteredEvents
+}


### PR DESCRIPTION
## What this PR does
- Adds an endpoint to fetch events registered by the authenticated user
- Uses the authenticated user context (no userId from client)
- Returns a frontend-friendly list of events

## Implementation details
- Queries registrations (`UserEvent`) scoped to the authenticated user
- Fetches related event data with selected fields only
- Flattens the response shape in the service layer

## Notes
- Returns an empty array if the user has no registered events

Closes #11 