### PR TITLE
feat(events): fetch event attendees for creator

### DIFF
--- a/src/controllers/event.controller.js
+++ b/src/controllers/event.controller.js
@@ -163,4 +163,50 @@ async function getMyCreatedEvents(req, res) {
     }
 }
 
-module.exports = { createEvent, getEvents, getEventByPublicId, registerUserForEvent, getMyRegisteredEvents, getMyCreatedEvents }
+async function getEventAttendees(req, res) {
+    const { userId } = req.user
+    const { publicId } = req.params
+
+    const result = eventSchema.EventPublicIdParamSchema.safeParse({
+        publicId
+    })
+
+    if (!result.success) {
+        return res.status(400).json({
+            success: false,
+            message: 'Invalid event Id'
+        })
+    }
+    try {
+        const attendees = await eventService.getEventAttendees(result.data.publicId, userId)
+        return res.status(200).json({
+            success: true,
+            attendees
+
+        })
+
+    } catch (err) {
+        if (err.code === 'EVENT_NOT_FOUND') {
+            return res.status(404).json({
+                success: false,
+                message: err.message
+            })
+        }
+
+        return res.status(500).json({
+            success: false,
+            message: 'Internal server error'
+        })
+
+    }
+}
+
+module.exports = {
+    createEvent,
+    getEvents,
+    getEventByPublicId,
+    registerUserForEvent,
+    getMyRegisteredEvents,
+    getMyCreatedEvents,
+    getEventAttendees
+}

--- a/src/repositories/event.repo.js
+++ b/src/repositories/event.repo.js
@@ -97,6 +97,14 @@ async function findEventsByCreatorId(creatorId) {
     })
 }
 
+async function findByPublicIdAndCreatorId(publicId, creatorId) {
+    return prisma.event.findFirst({
+        where: {
+            publicId,
+            creatorId
+        }
+    })
+}
 
 
 module.exports = {
@@ -104,5 +112,6 @@ module.exports = {
     getEvents,
     findEventByPublicId,
     findByPublicId,
-    findEventsByCreatorId
+    findEventsByCreatorId,
+    findByPublicIdAndCreatorId
 };

--- a/src/repositories/userEvent.repo.js
+++ b/src/repositories/userEvent.repo.js
@@ -44,8 +44,26 @@ async function findUserEventsByUserId(userId) {
 
 }
 
+async function findAttendeesByEventId(eventId) {
+    return prisma.userEvent.findMany({
+        where: {
+            eventId
+        },
+        select: {
+            user: {
+                select: {
+                    firstName: true,
+                    lastName: true,
+                    email: true
+                }
+            }
+        }
+    })
+}
+
 module.exports = {
     exists,
     createRegistration,
-    findUserEventsByUserId
+    findUserEventsByUserId,
+    findAttendeesByEventId
 }

--- a/src/routes/event.routes.js
+++ b/src/routes/event.routes.js
@@ -12,6 +12,8 @@ router.get('/me/created', authMiddleware, eventController.getMyCreatedEvents)
 
 router.get('/me/registered', authMiddleware, eventController.getMyRegisteredEvents)
 
+router.get('/:publicId/attendees', authMiddleware, eventController.getEventAttendees)
+
 router.post('/', authMiddleware, eventController.createEvent)
 
 router.post('/:publicId/register', authMiddleware, eventController.registerUserForEvent)

--- a/src/schemas/event.schema.js
+++ b/src/schemas/event.schema.js
@@ -39,9 +39,17 @@ const createEvent = z.object({
             }
         }
     })
+
+/**
+ * @deprecated Use EventPublicIdParamSchema
+ */
 const EventParamSchema = z.object({
     publicId: z.uuid()
 })
+
+const EventPublicIdParamSchema = z.object({
+    publicId: z.uuid()
+})
 module.exports = {
-    createEvent, EventParamSchema
+    createEvent, EventParamSchema, EventPublicIdParamSchema
 }

--- a/src/services/event.service.js
+++ b/src/services/event.service.js
@@ -48,4 +48,25 @@ async function getMyCreatedEvents(userId) {
     return eventRepo.findEventsByCreatorId(userId)
 }
 
-module.exports = { createEvent, getEvents, getEventByPublicId, registerUserForEvent, getMyCreatedEvents }
+async function getEventAttendees(publicId, userId) {
+    const event = await eventRepo.findByPublicIdAndCreatorId(publicId, userId)
+
+    if (!event) {
+        // TODO: replace with HttpError during error-handling refactor
+        const err = new Error('Event not found')
+        err.code = 'EVENT_NOT_FOUND'
+        throw err
+    }
+
+    const rows = await userEventRepo.findAttendeesByEventId(event.id)
+    return rows.map(r => r.user)
+}
+
+module.exports = {
+    createEvent,
+    getEvents,
+    getEventByPublicId,
+    registerUserForEvent,
+    getMyCreatedEvents,
+    getEventAttendees
+}


### PR DESCRIPTION
## What
Adds a creator-only endpoint to fetch attendees for an event.

## Details
- Introduced `GET /events/:publicId/attendees`
- Access restricted to event creator
- Event lookup scoped by `publicId + creatorId`
- Attendees fetched via `userEvent` using internal `eventId`
- Returns attendee name and email (for check-in use case only)
- Route params validated using Zod

## Notes
- Email exposure is limited strictly to this creator-only endpoint
- Temporary plain `Error` is used for not-found cases
- Error handling will be standardized in a follow-up refactor

Fixes #13 